### PR TITLE
Add IProductRepository interface for product management

### DIFF
--- a/Domain/Interfaces/IProductRepository.cs
+++ b/Domain/Interfaces/IProductRepository.cs
@@ -1,0 +1,21 @@
+﻿using Domain.Entities;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Domain.Interfaces
+{
+    public interface IProductRepository
+    {
+        Task<IEnumerable<Product>> GetAllAsync();
+        Task<Product?> GetByIdAsync(int id);
+        Task<IEnumerable<Product>> GetFavoritesAsync(int count = 3);
+        Task<IEnumerable<Product>> GetNewestAsync(int count = 3);
+        Task<Product> AddAsync(Product product);
+        Task UpdateAsync(Product product);
+        Task DeleteAsync(int id);
+        Task<bool> ExistsAsync(int id);
+    }
+}


### PR DESCRIPTION
Introduced the `IProductRepository` interface in the `Domain.Interfaces` namespace to standardize asynchronous operations for managing `Product` entities.

The interface includes methods for retrieving all products, fetching by ID, getting favorites and newest products, adding, updating, deleting, and checking existence of products. Default parameters are provided for some methods to enhance usability.

Added necessary `using` directives to support the implementation.